### PR TITLE
fix(sensor-map): support auto:<group>:{n} template syntax (v2.64.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.64.3] - 2026-07-01
+
+### Fixed
+
+- **HYMER Smart Sensors disappeared / `{n}` ghost entities (v2.64.2 regression)** — After the v2.64.2 sensor-map migration to the `{n}` placeholder syntax, all HYMER Smart Sensors (tyre pressure bus 70, temperature/humidity bus 74, contact bus 73, gas level bus 71) stopped producing data and instead created dead entities with a literal `{n}` in their name (e.g. `HSS Tyre{N} Status` → *unavailable*). Root cause: the sensor-map loader only recognised the legacy `auto:<group>:1` template form and silently rejected the new `auto:<group>:{n}` discriminator (`"{n}".isdigit()` is `False`), so those buses were never registered as auto-slot groups and inbound device frames were never matched. The loader now natively understands the `auto:<group>:{n}` template form (and still accepts the legacy `:1` form), and never registers an unresolved `{n}` placeholder name as an entity. Reported by @mcfly1969 on the ML-T 570 CrossOver (SCU firmware 1.13.0.0).
+
+### Documentation
+
+- **Auto-slot template guide** — Rewrote the *Pinned sensor mappings and auto-slot templates* section of [`docs/sensor-map.md`](docs/sensor-map.md) and the `README.md` brand-overlay walkthrough so users can write their own multi-device sensor JSON: clarified the `auto:<group>:{n}` syntax, corrected the (previously wrong) claim that numbering is shared across users — it is **per-install, starting at 1** — added a "write your own auto-slot family" recipe, and noted that auto-slot sensors need **no** `strings.json` / translations entries.
+
 ## [2.64.2] - 2026-06-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ For other HYMER users who need to map shared slots dynamically, see
 That section includes copy-paste JSON examples for:
 
 - fixed discriminators (`bus_name: "pin-6"`, `"pin-7"`)
-- dynamic SIU templates (`bus_name: "auto:<group>:1"`)
+- dynamic SIU templates (`bus_name: "auto:<group>:{n}"`; legacy `:1` anchor also accepted)
 - JSON label maps (`value_labels`, `int_labels`)
 
 This path is explicitly relevant for the BMC owner discussion in
@@ -936,10 +936,18 @@ Vehicle has 4 identical HYMER Smart tyre sensors. Each has slots 1–4 (status, 
 - All 4 entries share same `"bus_name": "auto:tyre:{n}"` group pattern → grouped together in auto-slot assignment
 - `#t{n}` suffix in key is a comment (never parsed)
 - Result: `sensor.hymer_hss_tyre1_pressure`, `sensor.hymer_hss_tyre2_pressure`, etc.
+- **No `strings.json` / translations entry needed** — auto-slot sensors derive a
+  readable display name from their key (`hss_tyre1_pressure` → "HSS Tyre1
+  Pressure"). This is also why you *cannot* pre-list them: the device count is
+  unbounded (`{n}` may become 5, 6, …). Only fixed-name sensors use Step 3.
 
 ---
 
 ### Step 3: Update strings.json and translations/en.json
+
+> **Skip this step for auto-slot `{n}` sensors** (Example 4). They already get a
+> friendly name from their key and are numbered at runtime, so there is nothing
+> to pre-translate. This step applies only to sensors with a **fixed** name.
 
 **Only for human-readable entity names** (most entity types). The integration looks up friendly names in:
 

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ Key format: `"bus_id,sensor_id"` or `"bus_id,sensor_id#group_id"` (the `#group_i
 | **`state_class`** | string | ❌ No | `"measurement"` (most sensors), `"total"` (cumulative), `"total_increasing"` (never resets) | `"measurement"` |
 | **`device_class`** | string | ❌ No | HA device class (enables icons, UOM, automations) | `"temperature"`, `"voltage"`, `"pressure"`, `"battery"` |
 | **`icon`** | string | ❌ No | MDI icon override | `"mdi:thermometer"`, `"mdi:battery"` |
-| **`bus_name`** | string | ❌ No | **Multi-device discriminator** (required for multi-device buses only). Use: fixed pins (`"pin-6"`), hex IDs (`"hex:1a2b3c4d"`), or auto-slot template (`"auto:tyre:1"`) | `"auto:tyre:1"` |
+| **`bus_name`** | string | ❌ No | **Multi-device discriminator** (required for multi-device buses only). Use: fixed pins (`"pin-6"`), hex IDs (`"hex:1a2b3c4d"`), or auto-slot template (`"auto:tyre:{n}"`) | `"auto:tyre:{n}"` |
 | **`transform`** | string | ❌ No | Raw value transform: `"div100"`, `"div1000"`, `"mul10"`, etc. Applied before unit display | `"div1000"` for mV → V |
 | **`restore`** | boolean | ❌ No | Restore the last known value after a Home Assistant restart until a fresh live value arrives. Useful for slowly-updating or standby-only sensors such as tank levels. **Currently implemented only for `platform: "sensor"`.** | `true` |
 | **`friendly_name`** | string | ❌ No | Override HA entity friendly_name. Normally auto-generated from name + strings.json | `"Front Left Tyre"` |
@@ -789,7 +789,7 @@ Special nested structure for complex multi-slot appliances.
 | **Integer enum sensor** (e.g. fridge mode, error codes) | `name`, `platform`, `int_labels` | `icon`, `_doc` |
 | **String enum sensor** (e.g. LTE quality) | `name`, `platform`, `value_labels` | — |
 | **Light with brightness** | Use 3 entries (on/off + brightness + color_temp) in lights section | `icon` |
-| **Multi-device bus** (e.g. 4 tyre sensors on bus 70) | `name`, `platform`, `bus_name: "auto:tyre:1"` | `device_class`, `unit`, `icon` |
+| **Multi-device bus** (e.g. 4 tyre sensors on bus 70) | `name`, `platform`, `bus_name: "auto:tyre:{n}"` | `device_class`, `unit`, `icon` |
 | **Fixed discriminator** (e.g. only 2 specific hex IDs, never more) | `name`, `platform`, `bus_name: "pin-6"` or `"hex:1a2b3c4d"` | — |
 
 ### Step 1: Identify your vehicle's bus/slot pairs
@@ -895,34 +895,34 @@ Creates: `select.hymer_fridge_cooling_step` with options "Off"–"High". Selecti
 Vehicle has 4 identical HYMER Smart tyre sensors. Each has slots 1–4 (status, pressure, temperature, battery). Raw hex IDs are different but unknown at JSON-write time. Use auto-slot template:
 
 ```json
-"70,1#t1": {
+"70,1#t{n}": {
   "_doc": "HYMER Smart tyre sensor #1 (auto-numbered), status readback.",
   "name": "hss_tyre{n}_status",
-  "bus_name": "auto:tyre:1",
+  "bus_name": "auto:tyre:{n}",
   "platform": "sensor",
   "icon": "mdi:car-tire-alert"
 },
-"70,2#t1": {
+"70,2#t{n}": {
   "name": "hss_tyre{n}_pressure",
-  "bus_name": "auto:tyre:1",
+  "bus_name": "auto:tyre:{n}",
   "unit": "bar",
   "platform": "sensor",
   "device_class": "pressure",
   "state_class": "measurement",
   "icon": "mdi:gauge"
 },
-"70,3#t1": {
+"70,3#t{n}": {
   "name": "hss_tyre{n}_temperature",
-  "bus_name": "auto:tyre:1",
+  "bus_name": "auto:tyre:{n}",
   "unit": "°C",
   "platform": "sensor",
   "device_class": "temperature",
   "state_class": "measurement",
   "icon": "mdi:thermometer"
 },
-"70,4#t1": {
+"70,4#t{n}": {
   "name": "hss_tyre{n}_battery",
-  "bus_name": "auto:tyre:1",
+  "bus_name": "auto:tyre:{n}",
   "unit": "%",
   "platform": "sensor",
   "device_class": "battery",
@@ -933,8 +933,8 @@ Vehicle has 4 identical HYMER Smart tyre sensors. Each has slots 1–4 (status, 
 
 **Key points:**
 - `"name"` contains `{n}` placeholder — replaced at runtime with slot number 1, 2, 3, 4
-- All 4 entries share same `"bus_name": "auto:tyre:1"` group → grouped together in auto-slot assignment
-- `#t1` suffix in key is a comment (never parsed)
+- All 4 entries share same `"bus_name": "auto:tyre:{n}"` group pattern → grouped together in auto-slot assignment
+- `#t{n}` suffix in key is a comment (never parsed)
 - Result: `sensor.hymer_hss_tyre1_pressure`, `sensor.hymer_hss_tyre2_pressure`, etc.
 
 ---
@@ -984,10 +984,10 @@ Same keys go into `translations/en.json` under each platform section. See [trans
 | Typo in unit (e.g. `"°C"` as `"C"`) | Copy-paste from reference examples or JSON field reference above |
 | `"unit"` but no `"device_class"` | Many units auto-infer device_class (V→voltage, %, °C→temperature); explicit is safer |
 | Int labels with string keys (e.g. `"1": "On"` instead of `1: "On"` or `"1": "On"` for JSON) | JSON int_labels keys **must be strings** (JSON doesn't have int keys): `{ "0": "Off", "1": "On" }` |
-| Multi-device bus without `"bus_name"` | Every entry on a multi-device bus needs `"bus_name": "auto:group:n"` or `"bus_name": "pin-6"` or similar discriminator |
+| Multi-device bus without `"bus_name"` | Every entry on a multi-device bus needs `"bus_name": "auto:group:{n}"` or `"bus_name": "pin-6"` or similar discriminator |
 | `{n}` placeholder in `"name"` but no `"bus_name": "auto:…"` | Placeholders only work in auto-slot templates; fixed names ignore them |
 | Forgot to update `strings.json` and `translations/en.json` | New entities show ugly translation-key names in HA (e.g. `entity.sensor.hymer_hss_tyre1_pressure` instead of friendly name) |
-| JSON keys like `"70,1#t1"` with wrong format | Format is `"bus_id,slot_id"` or `"bus_id,slot_id#comment"` — the `#comment` part doesn't affect parsing, but typos in `bus_id,slot_id` will create unmapped slots |
+| JSON keys like `"70,1#t{n}"` with wrong format | Format is `"bus_id,slot_id"` or `"bus_id,slot_id#comment"` — the `#comment` part doesn't affect parsing, but typos in `bus_id,slot_id` will create unmapped slots |
 
 ---
 
@@ -1006,10 +1006,10 @@ Same keys go into `translations/en.json` under each platform section. See [trans
     "8,2": { "name": "solar_voltage", "unit": "V", "platform": "sensor", "device_class": "voltage", "state_class": "measurement" },
     "11,1": { "name": "light_interior", "platform": "binary_sensor" },
     "34,1": { "name": "fridge_power", "platform": "switch", "icon": "mdi:fridge" },
-    "70,2#t1": {
+    "70,2#t{n}": {
       "_doc": "Multi-device tyre sensor pressure (auto-slot).",
       "name": "hss_tyre{n}_pressure",
-      "bus_name": "auto:tyre:1",
+      "bus_name": "auto:tyre:{n}",
       "unit": "bar",
       "platform": "sensor",
       "device_class": "pressure",

--- a/custom_components/hymer_connect/manifest.json
+++ b/custom_components/hymer_connect/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/BetaHydri/hymer-connect-ha-ble/issues",
   "loggers": ["hymer_connect"],
   "requirements": [],
-  "version": "2.64.1"
+  "version": "2.64.3"
 }

--- a/custom_components/hymer_connect/pia_decoder.py
+++ b/custom_components/hymer_connect/pia_decoder.py
@@ -112,13 +112,15 @@ _overlays_loaded: set[str] = set()
 # in the JSON is not portable.
 #
 # Instead, a JSON sensor entry may use a *template* discriminator of the form
-#   "bus_name": "auto:<group>:<n>"
+#   "bus_name": "auto:<group>:{n}"   (preferred, one entry covers all devices)
+#   "bus_name": "auto:<group>:1"    (legacy: concrete device #1 as template)
 # where <group> ties the four slots of one logical device together (so they
-# get the SAME number) and <n> is 1..N.  At decode time, the decoder observes
-# the distinct hex ids appearing on that bus, assigns each one the next free
-# slot number in stable first-seen order, and resolves the "auto:…" entries
-# accordingly.  The hex→number mapping is persisted to a small JSON file so the
-# numbering survives restarts: tyre "sensor 1" stays the same wheel every time.
+# get the SAME number) and {n}/1 marks the entry as an auto-slot template.  At
+# decode time, the decoder observes the distinct hex ids appearing on that bus,
+# assigns each one the next free slot number in stable first-seen order, and
+# resolves the "auto:…" entries accordingly.  The hex→number mapping is
+# persisted to a small JSON file so the numbering survives restarts: tyre
+# "sensor 1" stays the same wheel every time.
 #
 # Owners never edit hex ids.  They simply rename "Tyre sensor 1/2/3/4" in the
 # HA UI to the real wheel positions once, and the persisted map keeps it stable.
@@ -132,15 +134,17 @@ _overlays_loaded: set[str] = set()
 AUTO_SLOT_GROUPS: dict[int, dict[str, Any]] = {}
 
 # AUTO_SLOT_TEMPLATES: bus_id -> { sensor_id(int) -> template_dict }
-#   Captured from the JSON's *first* auto-slot device (the "...:1" entries) so
-#   that any later-numbered device on the same bus can have its name + entity
-#   metadata generated dynamically.  Each template_dict holds:
+#   Captured from the JSON's auto-slot template entry — either the "{n}" form
+#   (name already holds the "{n}" placeholder) or the legacy "…:1" device #1
+#   (name is turned into a "{n}" template) — so that any device number on the
+#   same bus can have its name + entity metadata generated dynamically.  Each
+#   template_dict holds:
 #     "name_tmpl": str with "{n}" placeholder (e.g. "hss_gaslevel{n}_percent")
 #     "group":     str (e.g. "gas")
 #     "unit", "transform", "meta": as parsed from the JSON entry
 #   This is what makes the auto-slot mechanism unbounded: the JSON only needs
-#   to define device #1 as a template; devices #2, #3, … are materialised at
-#   runtime by _materialise_auto_slot() the first time they are observed.
+#   one template entry per (bus, slot); devices #1, #2, #3, … are materialised
+#   at runtime by _materialise_auto_slot() the first time they are observed.
 AUTO_SLOT_TEMPLATES: dict[int, dict[int, dict[str, Any]]] = {}
 
 # AUTO_SLOT_ASSIGN: bus_id -> { hex_id(str without "hex:") -> slot_number(int) }
@@ -359,8 +363,13 @@ def _load_json_overlay(filename: str) -> int:
                         continue
                 if int_map:
                     JSON_INT_LABELS[name] = int_map
-            # Store entity metadata when a platform is declared
-            if "platform" in value:
+            # Store entity metadata when a platform is declared.  Names that
+            # still carry an unresolved "{n}" auto-slot placeholder are
+            # *templates*, not concrete entities — never register them directly
+            # (doing so created literal "…{n}…" ghost entities, the v2.64.2
+            # regression).  Concrete devices #1..N are materialised later by the
+            # decoder via _materialise_auto_slot().
+            if "platform" in value and "{n}" not in name:
                 meta = {k: value[k] for k in _ENTITY_FIELDS if k in value}
                 if unit is not None:
                     meta["unit"] = unit
@@ -374,44 +383,54 @@ def _load_json_overlay(filename: str) -> int:
         # satisfy the un-discriminated lookup.
         disc = value.get("bus_name") if isinstance(value, dict) else None
         if disc:
-            SENSOR_MAP_PINNED[(bus_id, sensor_id, disc)] = (name, unit, transform)
-            # Auto-slot template: "auto:<group>:<n>" registers this bus as an
-            # auto-numbered multi-device bus.  The entry stays in the pinned map
-            # under its literal "auto:…" key; the decoder rewrites an inbound
-            # "hex:…" discriminator to the matching "auto:<group>:<n>" key once
-            # the device has been assigned a stable slot number.
-            if disc.startswith("auto:"):
-                _parts = disc.split(":")
-                if len(_parts) == 3 and _parts[2].isdigit():
-                    _n = int(_parts[2])
-                    _grp = _parts[1]
-                    bucket = AUTO_SLOT_GROUPS.setdefault(
-                        bus_id, {"max": 0, "groups": set()}
-                    )
-                    bucket["groups"].add(_grp)
-                    if _n > bucket["max"]:
-                        bucket["max"] = _n
-                    # Capture a template from device #1 so higher-numbered
-                    # devices can be materialised on the fly.  The name must
-                    # contain the device number so we can swap it for "{n}";
-                    # we look for the literal "1" that follows the group name
-                    # (e.g. "hss_gaslevel1_percent" → "hss_gaslevel{n}_percent").
-                    if _n == 1:
-                        _meta = None
-                        if isinstance(value, dict) and "platform" in value:
-                            _meta = {
-                                k: value[k] for k in _ENTITY_FIELDS if k in value
-                            }
-                            if unit is not None:
-                                _meta["unit"] = unit
-                        _name_tmpl = _make_auto_name_template(name, _grp)
-                        AUTO_SLOT_TEMPLATES.setdefault(bus_id, {})[sensor_id] = {
-                            "name_tmpl": _name_tmpl,
-                            "group": _grp,
-                            "unit": unit,
-                            "transform": transform,
-                            "meta": _meta,
+            # Auto-slot discriminators come in two forms:
+            #   "auto:<group>:{n}"  — ONE template covering devices #1..N
+            #                          (preferred; no per-device JSON entries)
+            #   "auto:<group>:1"    — legacy concrete device #1 that also serves
+            #                          as the template (kept for backward compat)
+            # A literal "{n}" placeholder must NEVER be stored in the pinned map
+            # (no inbound "hex:…" frame can ever match "auto:tyre:{n}"); it only
+            # DEFINES the template.  Every other discriminator (e.g. "pin-6") is
+            # an ordinary pinned entry.
+            _parts = disc.split(":") if disc.startswith("auto:") else []
+            _is_tmpl = len(_parts) == 3 and _parts[2] == "{n}"
+            _is_num = len(_parts) == 3 and _parts[2].isdigit()
+
+            if not _is_tmpl:
+                SENSOR_MAP_PINNED[(bus_id, sensor_id, disc)] = (name, unit, transform)
+
+            if _is_tmpl or _is_num:
+                _grp = _parts[1]
+                _n = 1 if _is_tmpl else int(_parts[2])
+                bucket = AUTO_SLOT_GROUPS.setdefault(
+                    bus_id, {"max": 0, "groups": set()}
+                )
+                bucket["groups"].add(_grp)
+                if _n > bucket["max"]:
+                    bucket["max"] = _n
+                # Capture a template so any device number can be materialised on
+                # the fly.  For the "{n}" form the name already IS the template;
+                # for the legacy ":1" form derive it from the concrete device-#1
+                # name (e.g. "hss_gaslevel1_percent" → "hss_gaslevel{n}_percent").
+                if _is_tmpl or _n == 1:
+                    _meta = None
+                    if isinstance(value, dict) and "platform" in value:
+                        _meta = {
+                            k: value[k] for k in _ENTITY_FIELDS if k in value
                         }
+                        if unit is not None:
+                            _meta["unit"] = unit
+                    _name_tmpl = (
+                        name if _is_tmpl
+                        else _make_auto_name_template(name, _grp)
+                    )
+                    AUTO_SLOT_TEMPLATES.setdefault(bus_id, {})[sensor_id] = {
+                        "name_tmpl": _name_tmpl,
+                        "group": _grp,
+                        "unit": unit,
+                        "transform": transform,
+                        "meta": _meta,
+                    }
         else:
             SENSOR_MAP[(bus_id, sensor_id)] = (name, unit, transform)
         count += 1

--- a/docs/sensor-map.md
+++ b/docs/sensor-map.md
@@ -41,7 +41,7 @@ easier to use as a reference:
 - Only keep backward-compatibility or legacy-name notes when they still help
   users understand an existing entity name.
 
-## Multi-device buses and discriminators (v2.64.0+)
+## Pinned sensor mappings and auto-slot templates (v2.64.0+)
 
 ### The Problem: Shared Slots on Multi-Device Buses
 
@@ -53,60 +53,96 @@ The devices are distinguished **only** by their factory-assigned binary ID (PIA 
 - Each sensor has a different hex factory ID (e.g., `0x1a2b3c4d`, `0x1a2b3c4e`, …)
 - Without discrimination, all 4 would map to the same sensor name (`"tyre_pressure"`) — HA would create only 1 entity instead of 4
 
-### Solution 1: `bus_name` discriminator (pin-6, pin-7, hex:…)
+### Solution 1: fixed `bus_name` discriminator (pin-6, pin-7, …)
 
-The JSON `"sensors"` entry can declare an optional `"bus_name"` field to distinguish devices on the same bus:
+When a bus hosts a **small, fixed, known set** of devices that each report a
+**stable, human-readable** instance string (PIA field 10), give each one its own
+entry with an explicit `"bus_name"`. The canonical example is the two water-tank
+levels on bus 76, told apart by `pin-6` / `pin-7`:
 
 ```json
-"70,2": {
-  "name": "hss_tyre{n}_pressure",
-  "bus_name": "auto:tyre:{n}",
-  "unit": "bar",
-  "platform": "sensor"
-}
+"76,1#pin-6": { "name": "fresh_water_level", "bus_name": "pin-6", "unit": "%", "platform": "sensor" },
+"76,1#pin-7": { "name": "gray_water_level",  "bus_name": "pin-7", "unit": "%", "platform": "sensor" }
 ```
 
-When decoding a PIA response on bus 70 slot 2:
-1. If the response carries a `connectedComponentInstance` (field 10), the decoder looks up `(bus_id=70, sensor_id=2, bus_name_hex=...)` in **`SENSOR_MAP_PINNED`** (the "pinned" discriminator map)
-2. If found, use that name; otherwise fall back to `SENSOR_MAP[(70, 2)]` (the default)
-3. If no field 10 exists, use the default map
+- The `#pin-6` / `#pin-7` suffix on the JSON **key** is only there so the same
+  `76,1` pair can appear twice in one JSON object (JSON keys must be unique).
+  Everything after `#` is stripped before parsing — the real discriminator is
+  the `"bus_name"` field.
+- When decoding a bus 76 slot 1 frame, the decoder reads field 10, and looks up
+  `(76, 1, "pin-6")` in **`SENSOR_MAP_PINNED`**; if not found it falls back to
+  the plain `SENSOR_MAP[(76, 1)]`.
 
-### Solution 2: Auto-slot templates (auto:group:n)
+Use this when you know the exact instance strings up front and there are only a
+few of them. For **many identical devices with factory-random binary IDs**, use
+Solution 2 instead.
 
-For buses with **N identical devices and portable numbering**, the JSON uses a **template discriminator**:
+### Solution 2: auto-slot templates (`auto:<group>:{n}`)
+
+For a bus with **an unknown number of identical devices** whose instance IDs are
+opaque binary bytes (surfaced as `hex:…`), write **one template entry per slot**
+using the `{n}` placeholder. The decoder auto-numbers each physical device and
+expands `{n}` at runtime — you never list device #2, #3, #4 by hand:
 
 ```json
-"70,1#t{n}": { "name": "hss_tyre{n}_status", "bus_name": "auto:tyre:{n}", ... },
-"70,2#t{n}": { "name": "hss_tyre{n}_pressure", "bus_name": "auto:tyre:{n}", ... },
+"70,1#t{n}": { "name": "hss_tyre{n}_status",      "bus_name": "auto:tyre:{n}", ... },
+"70,2#t{n}": { "name": "hss_tyre{n}_pressure",    "bus_name": "auto:tyre:{n}", ... },
 "70,3#t{n}": { "name": "hss_tyre{n}_temperature", "bus_name": "auto:tyre:{n}", ... },
-"70,4#t{n}": { "name": "hss_tyre{n}_battery", "bus_name": "auto:tyre:{n}", ... },
+"70,4#t{n}": { "name": "hss_tyre{n}_battery",     "bus_name": "auto:tyre:{n}", ... }
 ```
 
 **How it works:**
-- The `"bus_name": "auto:tyre:{n}"` syntax means: **"auto-assign group 'tyre', device #n"**
-- The `#t{n}` suffix in the JSON key is just a comment (doesn't affect parsing); it's there for human readability
-- At **decode time**, the decoder observes distinct hex IDs arriving on bus 70 for the first time, assigns each one a **slot number** in stable first-seen order, and resolves the `auto:…` entries accordingly
-- **Example:** If the decoder sees hex IDs `[0xaabbccdd, 0xaabbccde, 0xaabbccdf, 0xaabbcce0]` in that order, they are assigned slot numbers 1, 2, 3, 4 respectively — **and this assignment persists across restarts** via a JSON file (`_auto_slots.json`)
-- On the second restart, the same 4 IDs will receive the same 4 slot numbers, so "tyre 1" stays on the same physical wheel every time
+- `"bus_name": "auto:<group>:{n}"` marks the entry as an **auto-slot template**.
+  `<group>` (e.g. `tyre`) ties all slots of one physical device to the **same**
+  number, so device #1's status/pressure/temperature/battery all share `n = 1`.
+- The `{n}` in both `"name"` and `"bus_name"` is a placeholder. It **must** be
+  written literally as `{n}` — the loader recognises it and captures the entry
+  as a template (native support since **v2.64.3**; before that only the legacy
+  `auto:<group>:1` anchor form below worked).
+- The `#t{n}` suffix on the JSON **key** is only there to keep the four `70,x`
+  keys unique and readable; it is stripped before parsing.
+- At **decode time** the decoder sees each distinct `hex:…` instance on bus 70,
+  assigns it the next free number in **stable first-seen order** (1, 2, 3, …),
+  and **persists** the `hex → number` map to `sensor_maps/_auto_slots.json` so
+  the numbering survives restarts — "tyre 1" stays the same wheel every time.
+- Devices are **unbounded**: a 5th tyre sensor simply becomes `n = 5`,
+  materialised on the fly with no JSON edit and no restart.
 
-**Result**: Users never edit hex IDs in JSON. They simply rename the HA entities once in the UI ("Tyre sensor 1" → "Front left tyre") and the persisted mapping keeps them stable.
+> **Numbering is per-install, not global.** Each Home Assistant installation
+> numbers its own devices starting at 1. There is no shared numbering across
+> users — a second owner's four tyre sensors are *their* 1–4, not 5–8.
 
-### Example: HYMER Smart Tyre Sensors (Bus 70)
+**Result**: owners never touch hex IDs. They rename the HA entities once in the
+UI ("Tyre sensor 1" → "Front left tyre") and the persisted map keeps them
+stable. To reset the numbering, delete `sensor_maps/_auto_slots.json` and
+restart.
+
+#### Legacy anchor form (`auto:<group>:1`)
+
+The older form spells device #1 out concretely and lets the decoder derive the
+`{n}` template from it. It is still accepted for backward compatibility:
 
 ```json
-"70,1#t{n}": { "_doc": "HYMER Smart tyre sensor #{n} (auto-numbered).", "name": "hss_tyre{n}_status", "bus_name": "auto:tyre:{n}", "platform": "sensor", "icon": "mdi:car-tire-alert" },
-"70,2#t{n}": { "name": "hss_tyre{n}_pressure", "bus_name": "auto:tyre:{n}", "unit": "bar", "platform": "sensor", "device_class": "pressure", "state_class": "measurement", "icon": "mdi:gauge" },
-"70,3#t{n}": { "name": "hss_tyre{n}_temperature", "bus_name": "auto:tyre:{n}", "unit": "°C", "platform": "sensor", "device_class": "temperature", "state_class": "measurement", "icon": "mdi:thermometer" },
-"70,4#t{n}": { "name": "hss_tyre{n}_battery", "bus_name": "auto:tyre:{n}", "unit": "%", "platform": "sensor", "device_class": "battery", "state_class": "measurement", "icon": "mdi:battery" },
+"70,2#t1": { "name": "hss_tyre1_pressure", "bus_name": "auto:tyre:1", ... }
 ```
 
-When the first user's 4 tyre sensors are observed on bus 70, they are assigned slot numbers 1, 2, 3, 4 in stable order.
-When a **second user with a different vehicle** adds their 4 tyre sensors, they are automatically assigned to slot numbers 5, 6, 7, 8 (or whatever the next available numbers are).
-Each user's tyre sensors are created in HA as:
-- `sensor.<device>_hss_tyre1_pressure`, `sensor.<device>_hss_tyre2_pressure`, …, `sensor.<device>_hss_tyre4_pressure`
-- And so on for temperature, battery, status
+Prefer the `{n}` form for new overlays — it is self-documenting and cannot be
+mistaken for a concrete device #1 entry.
 
-This works because the template name `"hss_tyre{n}_pressure"` contains a `{n}` placeholder, which is filled in at runtime by the decoder.
+#### Recipe: add your own auto-slot family
+
+1. Find the bus + slots via **Dynamic Slot Discovery** (see below). Enable the
+   `discovered_bus_X_slot_Y` sensors and watch which slots your devices report.
+2. Pick a short `<group>` name (e.g. `awning`, `battery2`).
+3. Add one template entry per slot to your brand overlay's `"sensors"` section:
+   ```json
+   "80,1#a{n}": { "name": "hss_awning{n}_state",    "bus_name": "auto:awning:{n}", "platform": "sensor", "icon": "mdi:awning-outline" },
+   "80,2#a{n}": { "name": "hss_awning{n}_position", "bus_name": "auto:awning:{n}", "unit": "%", "platform": "sensor", "state_class": "measurement" }
+   ```
+   Keep the `{n}` identical across the key suffix, `"name"`, and `"bus_name"`.
+4. Reload the integration. No `strings.json` / translations edit is needed —
+   auto-slot sensors derive a readable display name from their key
+   (`hss_awning1_position` → "HSS Awning1 Position").
 
 ### Example: Other Multi-Device Buses
 

--- a/docs/sensor-map.md
+++ b/docs/sensor-map.md
@@ -59,8 +59,8 @@ The JSON `"sensors"` entry can declare an optional `"bus_name"` field to disting
 
 ```json
 "70,2": {
-  "name": "hss_tyre1_pressure",
-  "bus_name": "auto:tyre:1",
+  "name": "hss_tyre{n}_pressure",
+  "bus_name": "auto:tyre:{n}",
   "unit": "bar",
   "platform": "sensor"
 }
@@ -76,15 +76,15 @@ When decoding a PIA response on bus 70 slot 2:
 For buses with **N identical devices and portable numbering**, the JSON uses a **template discriminator**:
 
 ```json
-"70,1#t1": { "name": "hss_tyre1_status", "bus_name": "auto:tyre:1", ... },
-"70,2#t1": { "name": "hss_tyre1_pressure", "bus_name": "auto:tyre:1", ... },
-"70,3#t1": { "name": "hss_tyre1_temperature", "bus_name": "auto:tyre:1", ... },
-"70,4#t1": { "name": "hss_tyre1_battery", "bus_name": "auto:tyre:1", ... },
+"70,1#t{n}": { "name": "hss_tyre{n}_status", "bus_name": "auto:tyre:{n}", ... },
+"70,2#t{n}": { "name": "hss_tyre{n}_pressure", "bus_name": "auto:tyre:{n}", ... },
+"70,3#t{n}": { "name": "hss_tyre{n}_temperature", "bus_name": "auto:tyre:{n}", ... },
+"70,4#t{n}": { "name": "hss_tyre{n}_battery", "bus_name": "auto:tyre:{n}", ... },
 ```
 
 **How it works:**
-- The `"bus_name": "auto:tyre:1"` syntax means: **"auto-assign group 'tyre', device #1"**
-- The `#t1` suffix in the JSON key is just a comment (doesn't affect parsing); it's there for human readability
+- The `"bus_name": "auto:tyre:{n}"` syntax means: **"auto-assign group 'tyre', device #n"**
+- The `#t{n}` suffix in the JSON key is just a comment (doesn't affect parsing); it's there for human readability
 - At **decode time**, the decoder observes distinct hex IDs arriving on bus 70 for the first time, assigns each one a **slot number** in stable first-seen order, and resolves the `auto:…` entries accordingly
 - **Example:** If the decoder sees hex IDs `[0xaabbccdd, 0xaabbccde, 0xaabbccdf, 0xaabbcce0]` in that order, they are assigned slot numbers 1, 2, 3, 4 respectively — **and this assignment persists across restarts** via a JSON file (`_auto_slots.json`)
 - On the second restart, the same 4 IDs will receive the same 4 slot numbers, so "tyre 1" stays on the same physical wheel every time
@@ -94,10 +94,10 @@ For buses with **N identical devices and portable numbering**, the JSON uses a *
 ### Example: HYMER Smart Tyre Sensors (Bus 70)
 
 ```json
-"70,1#t1": { "_doc": "HYMER Smart tyre sensor #1 (auto-numbered).", "name": "hss_tyre1_status", "bus_name": "auto:tyre:1", "platform": "sensor", "icon": "mdi:car-tire-alert" },
-"70,2#t1": { "name": "hss_tyre1_pressure", "bus_name": "auto:tyre:1", "unit": "bar", "platform": "sensor", "device_class": "pressure", "state_class": "measurement", "icon": "mdi:gauge" },
-"70,3#t1": { "name": "hss_tyre1_temperature", "bus_name": "auto:tyre:1", "unit": "°C", "platform": "sensor", "device_class": "temperature", "state_class": "measurement", "icon": "mdi:thermometer" },
-"70,4#t1": { "name": "hss_tyre1_battery", "bus_name": "auto:tyre:1", "unit": "%", "platform": "sensor", "device_class": "battery", "state_class": "measurement", "icon": "mdi:battery" },
+"70,1#t{n}": { "_doc": "HYMER Smart tyre sensor #{n} (auto-numbered).", "name": "hss_tyre{n}_status", "bus_name": "auto:tyre:{n}", "platform": "sensor", "icon": "mdi:car-tire-alert" },
+"70,2#t{n}": { "name": "hss_tyre{n}_pressure", "bus_name": "auto:tyre:{n}", "unit": "bar", "platform": "sensor", "device_class": "pressure", "state_class": "measurement", "icon": "mdi:gauge" },
+"70,3#t{n}": { "name": "hss_tyre{n}_temperature", "bus_name": "auto:tyre:{n}", "unit": "°C", "platform": "sensor", "device_class": "temperature", "state_class": "measurement", "icon": "mdi:thermometer" },
+"70,4#t{n}": { "name": "hss_tyre{n}_battery", "bus_name": "auto:tyre:{n}", "unit": "%", "platform": "sensor", "device_class": "battery", "state_class": "measurement", "icon": "mdi:battery" },
 ```
 
 When the first user's 4 tyre sensors are observed on bus 70, they are assigned slot numbers 1, 2, 3, 4 in stable order.
@@ -111,15 +111,15 @@ This works because the template name `"hss_tyre{n}_pressure"` contains a `{n}` p
 ### Example: Other Multi-Device Buses
 
 - **Bus 74** — HYMER Smart temperature sensors (2-4 devices per vehicle)
-  - `"auto:temp:1"` for the first temperature sensor, `"auto:temp:2"` for the second, etc.
+  - `"auto:temp:{n}"` with `{n}` resolved per discovered device
   - 3 slots per device: temperature, humidity, battery
 
 - **Bus 73** — HYMER Smart contact sensors (door/window sensors; 1-N per vehicle)
-  - `"auto:contact:1"` for the first contact sensor, etc.
+  - `"auto:contact:{n}"` with `{n}` resolved per discovered device
   - 2 slots per device: status, battery
 
 - **Bus 71** — HYMER Smart gas-bottle sensors (1-N per vehicle)
-  - `"auto:gas:1"` for the first gas sensor, etc.
+  - `"auto:gas:{n}"` with `{n}` resolved per discovered device
   - 2 slots per device: gas level percentage, height
 
 ### JSON label maps: value_labels and int_labels (v2.64.0+)

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -175,15 +175,15 @@ For lights with color temperature, add a third sub-sensor (suffix `_color_temp`)
    ```jsonc
    "climate": {
      "selects": {
-       "fridge_dometic_freezer": {
+       "fridge_compressor_freezer": {
          "control_bus": 114,
          "options": ["Off", "1", "2", "3"],
-         "read":  { "step_sensor": "fridge_dometic_freezer", "off_value": 0 },
+         "read":  { "step_sensor": "fridge_compressor_freezer", "off_value": 0 },
          "writes": {
            "off":  [{ "sid": 4, "uint": 0 }],
            "step": [{ "sid": 4, "uint": "$option_int" }]
          },
-         "name": "Dometic freezer compartment",
+         "name": "Compressor fridge freezer",
          "icon": "mdi:snowflake"
        }
      }
@@ -192,7 +192,7 @@ For lights with color temperature, add a third sub-sensor (suffix `_color_temp`)
 
 2. **`strings.json`** — **no edit needed**.
 3. **`translations/en.json`** — **no edit needed**.
-4. Reload the integration. The entity `select.fridge_dometic_freezer_ctrl` shows up with the display name *"Dometic freezer compartment"* read from the JSON.
+4. Reload the integration. The entity `select.fridge_compressor_freezer_ctrl` shows up with the display name *"Compressor fridge freezer"* read from the JSON.
 
 > **What about the existing fridge / heater selects** (`fridge_mode_ctrl`, `boiler_mode_ctrl`, `heater_energy_ctrl`)? Those use the **classic** code-driven driver (`HymerFridgeSelect` etc.) and **do** need entries in `entity.select` of both translation files. The stepped-switch driver is the new generic one — only it is translation-free.
 

--- a/tools/_test_auto_slot_n.py
+++ b/tools/_test_auto_slot_n.py
@@ -1,0 +1,102 @@
+"""Offline smoke-test for auto-slot {n} template expansion.
+
+Loads the real hymer.json overlay (which uses the "{n}" template form) and
+verifies:
+  1. Buses 70/71/73/74 are registered as auto-slot groups.
+  2. No ENTITY_DEFS key contains a literal "{n}" placeholder (no ghosts).
+  3. A synthetic bus-70 PIA frame carrying a binary connectedComponentInstance
+     materialises hss_tyre1_* correctly, and a second instance materialises #2.
+
+Run:  python tools/_test_auto_slot_n.py
+Exit code 0 = pass, 1 = fail.  Deletes any _auto_slots.json it creates.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PIA = _ROOT / "custom_components" / "hymer_connect" / "pia_decoder.py"
+
+# Load pia_decoder.py directly by path so we don't trigger the package
+# __init__.py (which imports Home Assistant, unavailable in this venv).
+_spec = importlib.util.spec_from_file_location("hc_pia_decoder", _PIA)
+pd = importlib.util.module_from_spec(_spec)
+sys.modules["hc_pia_decoder"] = pd
+_spec.loader.exec_module(pd)
+
+
+def _build_frame(bus_id: int, sensor_id: int, *, float_val: float, instance: bytes) -> bytes:
+    """Build a minimal CCValue protobuf: f1=sid, f2=bus, f6=float, f10=instance."""
+    body = pd._encode_varint_field(1, sensor_id)
+    body += pd._encode_varint_field(2, bus_id)
+    body += pd._encode_float_field(6, float_val)
+    body += pd._encode_bytes_field(10, instance)
+    # Nest one level so _extract_sensors_recursive walks into it (depth 1).
+    return pd._encode_bytes_field(2, body)
+
+
+def main() -> int:
+    store = pd._AUTO_SLOT_STORE
+    pre_existing = store.exists()
+
+    pd.load_sensor_map("hymer")
+
+    ok = True
+
+    # 1. Auto-slot groups registered.
+    for bus in (70, 71, 73, 74):
+        if bus not in pd.AUTO_SLOT_GROUPS:
+            print(f"FAIL: bus {bus} not in AUTO_SLOT_GROUPS")
+            ok = False
+    if ok:
+        print(f"PASS: auto-slot groups = {sorted(pd.AUTO_SLOT_GROUPS)}")
+
+    # 2. No {n} ghost entities.
+    ghosts = [k for k in pd.ENTITY_DEFS if "{n}" in k]
+    if ghosts:
+        print(f"FAIL: {len(ghosts)} ghost ENTITY_DEFS with '{{n}}': {ghosts[:5]}")
+        ok = False
+    else:
+        print("PASS: no '{n}' ghost entities in ENTITY_DEFS")
+
+    # 3. Templates captured for bus 70 slots 1-4.
+    tmpl70 = pd.AUTO_SLOT_TEMPLATES.get(70, {})
+    if set(tmpl70) != {1, 2, 3, 4}:
+        print(f"FAIL: bus 70 templates = {sorted(tmpl70)} (expected 1-4)")
+        ok = False
+    else:
+        print(f"PASS: bus 70 template name_tmpl(2) = {tmpl70[2]['name_tmpl']!r}")
+
+    # 4. Decode two devices -> materialise hss_tyre1_* and hss_tyre2_*.
+    dev_a = bytes.fromhex("03eded12d9d6")
+    dev_b = bytes.fromhex("03eded12d7be")
+
+    out: dict = {}
+    pd._extract_sensors_recursive(_build_frame(70, 2, float_val=3.71, instance=dev_a), out, depth=0)
+    pd._extract_sensors_recursive(_build_frame(70, 2, float_val=4.87, instance=dev_b), out, depth=0)
+
+    if out.get("hss_tyre1_pressure") == 3.71 and out.get("hss_tyre2_pressure") == 4.87:
+        print(f"PASS: materialised tyre1={out['hss_tyre1_pressure']} tyre2={out['hss_tyre2_pressure']}")
+    else:
+        print(f"FAIL: expected tyre1=3.71 tyre2=4.87, got {out}")
+        ok = False
+
+    # Both concrete names must now be real ENTITY_DEFS (for sensor.py pickup).
+    for name in ("hss_tyre1_pressure", "hss_tyre2_pressure"):
+        if name not in pd.ENTITY_DEFS:
+            print(f"FAIL: {name} not registered in ENTITY_DEFS after materialise")
+            ok = False
+
+    # Cleanup: remove store file if the test created it.
+    if not pre_existing and store.exists():
+        store.unlink()
+
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes the v2.64.2 regression where all HYMER Smart Sensors (bus 70/71/73/74) went unavailable and literal `{n}` ghost entities were created. The sensor-map loader now natively understands the `auto:<group>:{n}` template form (legacy `:1` still accepted) and never registers an unresolved `{n}` placeholder as an entity.

- Adds offline regression test `tools/_test_auto_slot_n.py`.
- Updates `docs/sensor-map.md` + `README.md` so users can author their own auto-slot JSON.

Reported by @mcfly1969 (ML-T 570 CrossOver, SCU 1.13.0.0).