### PR TITLE
fix(ble): wrap setValues commands as BleProtocol.request (field 1), not response (field 2)

### DIFF
--- a/custom_components/hymer_connect/ble_client.py
+++ b/custom_components/hymer_connect/ble_client.py
@@ -275,6 +275,35 @@ def _encode_bytes_field(field: int, value: bytes) -> bytes:
     return _encode_key(field, _WIRE_LEN) + _encode_varint(len(value)) + value
 
 
+def _unwrap_cloud_envelope(raw: bytes) -> bytes:
+    """Return the bare Request from a pia_decoder command payload.
+
+    ``pia_decoder.build_light_command`` / ``build_multi_sensor_command`` wrap
+    the Request in protobuf field 2 -- the envelope the cloud DataHub expects.
+    Over BLE, field 2 is ``BleProtocol.response``, so a field-2-wrapped command
+    is parsed by the SCU as a *response*, matched against no outstanding
+    request, and silently discarded (the "0/5 dropped, no ACK" symptom). Strip
+    the field-2 wrapper here so the command can be rewrapped as
+    ``BleProtocol.request`` (field 1), exactly as the pairing path already does.
+
+    Payloads that are not field-2-wrapped are returned unchanged, so this is
+    safe for any already-bare Request.
+    """
+    if not raw or raw[0] != 0x12:  # 0x12 = field 2, wire type 2 (length-delimited)
+        return raw
+    idx = 1
+    length = 0
+    shift = 0
+    while idx < len(raw):
+        byte = raw[idx]
+        idx += 1
+        length |= (byte & 0x7F) << shift
+        if not (byte & 0x80):
+            break
+        shift += 7
+    return raw[idx:idx + length]
+
+
 def _decode_len_delimited(data: bytes, offset: int) -> tuple[bytes, int]:
     length, offset = _decode_varint(data, offset)
     end = offset + length
@@ -1436,14 +1465,24 @@ class ScuBleClient:
         if not self._tls_established:
             raise BleTransportError("TLS not established")
         raw = base64.b64decode(b64_payload)
-        pia_frame = encode_ble_pia_frame(raw)
+        # pia_decoder wraps command payloads in field 2 (the cloud DataHub
+        # envelope). Over BLE, field 2 is BleProtocol.response, so a
+        # field-2-wrapped command is parsed by the SCU as a response and
+        # silently dropped. Rewrap as BleProtocol.request (field 1), the same
+        # way the pairing path does.
+        request_msg = _unwrap_cloud_envelope(raw)
+        ble_protocol = _encode_bytes_field(_BLE_PROTOCOL_REQUEST_FIELD, request_msg)
+        pia_frame = encode_ble_pia_frame(ble_protocol)
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
                 "BLE PIA SEND %s: plaintext=%d B framed=%d B hex=%s",
                 self._scu_address, len(raw), len(pia_frame), raw.hex(),
             )
         encrypted = self._tls.encrypt(pia_frame)
-        await self._write_to_scu(encrypted)
+        # Write-with-response: at low MTU a command spread over many GATT chunks
+        # overruns the SCU NUS RX buffer without ACKs (the same reason the TLS
+        # handshake and PairMobileRequest force it).
+        await self._write_to_scu(encrypted, force_response=True)
 
     async def listen(self) -> None:
         """Listen for PIA responses from the SCU and dispatch them."""

--- a/tools/_test_ble_command_wrapper.py
+++ b/tools/_test_ble_command_wrapper.py
@@ -1,0 +1,67 @@
+"""Offline regression test for the BLE command wrapper.
+
+A setValues command sent over BLE must be wrapped as BleProtocol.request
+(field 1). pia_decoder wraps command payloads in field 2 (the cloud DataHub
+envelope); over BLE field 2 is BleProtocol.response, so a field-2-wrapped
+command is parsed by the SCU as a response and silently discarded. This pins
+the fix in ble_client.send_pia_command (via _unwrap_cloud_envelope).
+
+ble_client imports bleak lazily and no Home Assistant modules at import time,
+so it loads here without stubbing.
+
+Run:  python tools/_test_ble_command_wrapper.py
+Exit code 0 = pass, 1 = fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_BLE = _ROOT / "custom_components" / "hymer_connect" / "ble_client.py"
+
+_spec = importlib.util.spec_from_file_location("_ble_client_under_test", _BLE)
+_ble = importlib.util.module_from_spec(_spec)
+# Register before exec so @dataclass (with `from __future__ import annotations`)
+# can resolve the module during class processing.
+sys.modules[_spec.name] = _ble
+_spec.loader.exec_module(_ble)
+
+_failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("PASS" if cond else "FAIL"), "-", msg)
+    if not cond:
+        _failures.append(msg)
+
+
+# A synthetic bare Request (its content is irrelevant to the wrapping).
+bare = _ble._encode_bytes_field(1, b"\x08\x2a")
+# The cloud encoder wraps the Request in field 2 (tag 0x12) -- the DataHub envelope.
+cloud = _ble._encode_bytes_field(2, bare)
+
+check(cloud[0] == 0x12, "cloud command payload is field-2 wrapped (tag 0x12)")
+check(_ble._unwrap_cloud_envelope(cloud) == bare,
+      "_unwrap_cloud_envelope recovers the bare Request from the field-2 envelope")
+
+# An already-bare payload (starts with field 1, tag 0x0a) must pass through unchanged.
+already_bare = b"\x0a\x02\x08\x2a"
+check(_ble._unwrap_cloud_envelope(already_bare) == already_bare,
+      "already-bare payload passes through unchanged")
+
+# The re-wrap: BleProtocol.request (field 1, tag 0x0a), never response (field 2).
+request_msg = _ble._unwrap_cloud_envelope(cloud)
+ble_protocol = _ble._encode_bytes_field(_ble._BLE_PROTOCOL_REQUEST_FIELD, request_msg)
+check(ble_protocol[0] == 0x0a, "command wraps as BleProtocol.request (field 1, tag 0x0a)")
+check(ble_protocol[0] != 0x12, "command is NOT wrapped as BleProtocol.response (field 2)")
+check(ble_protocol == _ble._encode_bytes_field(1, bare),
+      "the field-1 wrapper contains exactly the original Request")
+
+if _failures:
+    print(f"\n{len(_failures)} check(s) FAILED")
+    sys.exit(1)
+print("\nALL PASS")
+sys.exit(0)


### PR DESCRIPTION
## TL;DR

BLE `setValues` writes aren't dropped by the SCU firmware — they're being sent wrapped in the wrong protobuf field, so the SCU parses each command as a *response* and silently discards it. This is a one-helper fix in `send_pia_command`, plus a standalone test. Your pairing path already does the right thing; this makes commands match it.

## Evidence it actually works

I verified the full BLE path end to end on a real vehicle (**Grand Canyon S 700, SCU firmware 1.49.7**), from a Linux/BlueZ host inside the van with the **LTE completely offline** (cloud API returning `SCU_IS_NOT_ONLINE` to everything):

- bond → TLS (`TLSv1.1 AES128-SHA`) → `PairMobileRequest` (minted a remote refresh token over BLE) → a `setValues` write that returned **`status=1` (SUCCESS)** and physically actuated the load.
- Before app-level pairing completed, the same write returned **`status=5` (ACCESS_DENIED)** — a real, structured response with a matching `request_id`.

With no cloud reachable, those responses can't be cloud echoes, and they aren't silence. So the SCU does parse and execute BLE `setValues`. That means the "0/5 silently dropped" behind the v2.62.24 removal was the SCU never *recognising* the message as a request — not the firmware refusing writes.

## Root cause — a field-1 vs field-2 asymmetry

`send_pia_command` frames the `pia_decoder` payload directly:

```python
raw = base64.b64decode(b64_payload)
pia_frame = encode_ble_pia_frame(raw)   # framed as-is
```

But `pia_decoder.build_light_command` / `build_multi_sensor_command` end with `_encode_bytes_field(2, wrapper)` — the payload is wrapped in **field 2**, which is correct for the cloud DataHub. Over BLE, field 2 is **`BleProtocol.response`**. So the SCU reads every command as a response, matches it against no outstanding request, and drops it — no error, no ACK.

Your pairing path already wraps correctly in field 1:

```python
ble_protocol = _encode_bytes_field(_BLE_PROTOCOL_REQUEST_FIELD, request_msg)  # field 1
return encode_ble_pia_frame(ble_protocol)
```

This PR makes `send_pia_command` do the same: unwrap the field-2 cloud envelope and rewrap as `BleProtocol.request` before framing.

## Also: write-with-response on the command path

`send_pia_command` used the default `_write_to_scu(encrypted)`. At low MTU a command spread over many GATT chunks overruns the SCU NUS RX buffer without ACKs — the same overflow you already handle by forcing write-with-response for the TLS handshake and `PairMobileRequest`. This PR forces it for commands too.

## The change

- `ble_client._unwrap_cloud_envelope()` — strips the field-2 wrapper; passes already-bare payloads through unchanged (safe for anything not field-2-wrapped).
- `send_pia_command` rewraps as `BleProtocol.request` (field 1) and forces write-with-response.
- `tools/_test_ble_command_wrapper.py` — standalone (no HA/bleak needed), asserts the command is wrapped in field 1 (tag `0x0a`), never field 2, and round-trips the Request. `python tools/_test_ble_command_wrapper.py` → all pass.

## Scope note

This corrects the encoding in `send_pia_command`. Whether/how to re-route writes back through BLE in the coordinator is your call — I've deliberately left the routing alone so this stays a minimal, reviewable fix.

Two gotchas that I think produced the earlier "BLE ACKs = cloud echoes" reading, in case useful: the native GATT write resolves immediately regardless, and `CCService.setValues` updates the app's store optimistically before any response — so neither is an acknowledgement. The only real ACK is a `BleProtocol.response` whose `request_id` matches.

Caveat: your decisive test was a GC S600 on firmware 1.12.0.0; mine is an S700 on 1.49.7, so I can't fully rule out a firmware difference. But the field-1 wrapper is wrong on any firmware and fully explains a silent 0/5.

Thanks for the pairing groundwork — it's what this is built on. Happy to adjust anything to fit your conventions.