### PR TITLE
feat(climate): aggregated A/C thermostat entities for Teleco/Saphir (v2.78.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.78.0] - 2026-08-25
+
+### Added
+
+- **Air-conditioner thermostat (`climate`) entities for single-zone A/C units.** The Teleco Telair DualClima (bus 36), Truma Saphir Compact (bus 79) and Saphir Comfort RC (bus 89) now expose a proper Home Assistant **climate card** — HVAC mode (Off/Cool/Heat/Fan/Dry/Auto), target + current temperature, and fan mode — aggregating the slot-level controls added in v2.77.0 into one thermostat. Each entity is **observation-gated** (created only when the vehicle reports the bus) and JSON-driven from the new `climate.air_conditioners` section. Enum wire values match the decompiled EHG app (`AIRCON_MODE_OPTIONS` / `FAN_MODE_OPTIONS`); **write paths are UNVERIFIED** test controls until confirmed on-vehicle. The granular per-slot select/number controls remain available. The dual-zone Airxcel AC Gateway (bus 95, separate heat/cool targets) and the Timberline heaters (buses 124/125) keep their slot-level controls for now; aggregated climate cards for those will follow.
+
+No entity IDs change for existing vehicles and no configuration migration is required. As always after a HACS update, **restart** Home Assistant.
+
 ## [2.77.0] - 2026-08-25
 
 ### Added

--- a/custom_components/hymer_connect/climate.py
+++ b/custom_components/hymer_connect/climate.py
@@ -44,9 +44,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up HYMER Connect climate from a config entry."""
-    from .pia_decoder import get_truma_heater_defs
+    from .pia_decoder import get_air_conditioner_defs, get_truma_heater_defs
 
     coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Single-zone air-conditioners (Teleco / Saphir …) — each observation-gated.
+    _setup_air_conditioners(coordinator, entry, async_add_entities, get_air_conditioner_defs())
+
     heater_defs = get_truma_heater_defs()
     if not heater_defs:
         _LOGGER.debug("Climate platform: no truma_heater definition in JSON — skipping")
@@ -269,4 +273,216 @@ class HymerHeaterClimate(
                     if self._optimistic_temp and abs(setpoint - self._optimistic_temp) < 0.5:
                         self._optimistic_mode = None
                         self._optimistic_temp = None
+        super()._handle_coordinator_update()
+
+
+# Wire values (from the decompiled EHG app) -> HA HVAC / fan modes.
+_AC_MODE_TO_HVAC: dict[str, HVACMode] = {
+    "OFF": HVACMode.OFF,
+    "FAN": HVACMode.FAN_ONLY,
+    "VENTILATION": HVACMode.FAN_ONLY,
+    "COOL": HVACMode.COOL,
+    "HEAT": HVACMode.HEAT,
+    "DEHUMIDIFY": HVACMode.DRY,
+    "AUTO": HVACMode.AUTO,
+}
+_AC_HVAC_TO_MODE: dict[HVACMode, str] = {
+    HVACMode.OFF: "OFF",
+    HVACMode.FAN_ONLY: "FAN",
+    HVACMode.COOL: "COOL",
+    HVACMode.HEAT: "HEAT",
+    HVACMode.DRY: "DEHUMIDIFY",
+    HVACMode.AUTO: "AUTO",
+}
+_AC_FAN_MODES = ["OFF", "LOW", "MID", "HIGH", "NIGHT", "AUTO"]
+
+
+def _setup_air_conditioners(
+    coordinator: HymerConnectCoordinator,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    ac_defs: tuple[tuple[str, dict[str, Any]], ...],
+) -> None:
+    """Create one observation-gated AC climate entity per def."""
+    if not ac_defs:
+        return
+    created: set[str] = set()
+
+    @callback
+    def _discover() -> None:
+        if not coordinator.data:
+            return
+        sensors = coordinator.data.get("signalr_sensors")
+        if not isinstance(sensors, dict):
+            return
+        for key, ac_def in ac_defs:
+            if key in created:
+                continue
+            gate = ac_def.get("mode_sensor") or ac_def.get("current_sensor")
+            # Ungated defs (require_observed false) are created immediately.
+            if ac_def.get("require_observed") and gate and gate not in sensors:
+                continue
+            created.add(key)
+            async_add_entities([HymerACClimate(coordinator, entry, key, ac_def)])
+            _LOGGER.info("Air-conditioner climate materialised: %s (bus %s)",
+                         key, ac_def.get("control_bus"))
+
+    _discover()
+    entry.async_on_unload(coordinator.async_add_listener(_discover))
+
+
+class HymerACClimate(CoordinatorEntity[HymerConnectCoordinator], ClimateEntity):
+    """Single-zone air-conditioner climate (target/current/mode/fan).
+
+    JSON-driven from ``"climate"."air_conditioners"``.  All writes are
+    observation-gated test controls until confirmed on-vehicle.
+    """
+
+    _attr_has_entity_name = True
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1.0
+    _attr_icon = "mdi:air-conditioner"
+    _attr_fan_modes = _AC_FAN_MODES
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+    )
+
+    def __init__(
+        self,
+        coordinator: HymerConnectCoordinator,
+        entry: ConfigEntry,
+        key: str,
+        ac_def: dict[str, Any],
+    ) -> None:
+        super().__init__(coordinator)
+        self._key = key
+        self._bus = int(ac_def["control_bus"])
+        self._target_sid = int(ac_def.get("target_sid", 1))
+        self._mode_sid = int(ac_def.get("mode_sid", 3))
+        self._fan_sid = int(ac_def.get("fan_sid", 4))
+        self._target_sensor = ac_def.get("target_sensor", "")
+        self._current_sensor = ac_def.get("current_sensor", "")
+        self._mode_sensor = ac_def.get("mode_sensor", "")
+        self._fan_sensor = ac_def.get("fan_sensor", "")
+        self._attr_min_temp = float(ac_def.get("min_temp", 16))
+        self._attr_max_temp = float(ac_def.get("max_temp", 32))
+        self._attr_name = ac_def.get("name", "Air conditioner")
+        self._attr_unique_id = f"{entry.entry_id}_ac_{key}_b{self._bus}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": "HYMER",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        self._attr_hvac_modes = [
+            HVACMode.OFF, HVACMode.FAN_ONLY, HVACMode.COOL,
+            HVACMode.HEAT, HVACMode.DRY, HVACMode.AUTO,
+        ]
+        self._optimistic_mode: HVACMode | None = None
+        self._optimistic_temp: float | None = None
+        self._optimistic_fan: str | None = None
+
+    def _sensor(self, name: str) -> Any:
+        if not name or self.coordinator.data is None:
+            return None
+        return _resolve_path(self.coordinator.data, f"signalr_sensors.{name}")
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        if self._optimistic_mode is not None:
+            return self._optimistic_mode
+        raw = self._sensor(self._mode_sensor)
+        if isinstance(raw, str):
+            return _AC_MODE_TO_HVAC.get(raw.upper())
+        return None
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        mode = self.hvac_mode
+        if mode == HVACMode.COOL:
+            return HVACAction.COOLING
+        if mode == HVACMode.HEAT:
+            return HVACAction.HEATING
+        if mode == HVACMode.DRY:
+            return HVACAction.DRYING
+        if mode == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+        if mode == HVACMode.OFF:
+            return HVACAction.OFF
+        return HVACAction.IDLE
+
+    @property
+    def current_temperature(self) -> float | None:
+        val = self._sensor(self._current_sensor)
+        try:
+            return float(val) if val is not None else None
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        if self._optimistic_temp is not None:
+            return self._optimistic_temp
+        val = self._sensor(self._target_sensor)
+        try:
+            return float(val) if val is not None else None
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def fan_mode(self) -> str | None:
+        if self._optimistic_fan is not None:
+            return self._optimistic_fan
+        raw = self._sensor(self._fan_sensor)
+        return raw if isinstance(raw, str) and raw in _AC_FAN_MODES else None
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        wire = _AC_HVAC_TO_MODE.get(hvac_mode)
+        if wire is None:
+            return
+        await self.coordinator.async_send_multi_sensor_command([
+            {"bus_id": self._bus, "sensor_id": self._mode_sid, "str_value": wire},
+        ])
+        self._optimistic_mode = hvac_mode
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is None:
+            return
+        await self.coordinator.async_send_multi_sensor_command([
+            {"bus_id": self._bus, "sensor_id": self._target_sid, "float_value": float(temp)},
+        ])
+        self._optimistic_temp = float(temp)
+        self.async_write_ha_state()
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        if fan_mode not in _AC_FAN_MODES:
+            return
+        await self.coordinator.async_send_multi_sensor_command([
+            {"bus_id": self._bus, "sensor_id": self._fan_sid, "str_value": fan_mode},
+        ])
+        self._optimistic_fan = fan_mode
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        # Clear optimistic flags once the SCU readback matches.
+        if self.coordinator.data:
+            raw_mode = self._sensor(self._mode_sensor)
+            if (
+                self._optimistic_mode is not None
+                and isinstance(raw_mode, str)
+                and _AC_MODE_TO_HVAC.get(raw_mode.upper()) == self._optimistic_mode
+            ):
+                self._optimistic_mode = None
+            raw_fan = self._sensor(self._fan_sensor)
+            if self._optimistic_fan is not None and raw_fan == self._optimistic_fan:
+                self._optimistic_fan = None
+            raw_temp = self._sensor(self._target_sensor)
+            if self._optimistic_temp is not None and raw_temp is not None:
+                try:
+                    if abs(float(raw_temp) - self._optimistic_temp) < 0.5:
+                        self._optimistic_temp = None
+                except (ValueError, TypeError):
+                    pass
         super()._handle_coordinator_update()

--- a/custom_components/hymer_connect/manifest.json
+++ b/custom_components/hymer_connect/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/BetaHydri/hymer-connect-ha-ble/issues",
   "loggers": ["hymer_connect"],
   "requirements": [],
-  "version": "2.77.0"
+  "version": "2.78.0"
 }

--- a/custom_components/hymer_connect/pia_decoder.py
+++ b/custom_components/hymer_connect/pia_decoder.py
@@ -89,6 +89,11 @@ SWITCH_DEFS: dict[str, dict[str, Any]] = {}
 # climate.py and select.py to parameterize write commands per brand.
 CLIMATE_DEFS: dict[str, dict[str, Any]] = {}
 
+# Single-zone air-conditioner climate definitions (v2.78.0+) loaded from the
+# ``"climate"."air_conditioners"`` JSON subsection.  Each drives one
+# :class:`climate.HymerACClimate` thermostat entity (target/current/mode/fan).
+AC_CLIMATE_DEFS: dict[str, dict[str, Any]] = {}
+
 # Generic stepped-switch select definitions (v2.63.0+) loaded from the
 # ``"climate"."selects"`` JSON subsection.  Drives appliances exposing a
 # small set of integer steps (fridge cooling 1-5, freezer 1-3, fan
@@ -501,6 +506,12 @@ def _load_json_overlay(filename: str) -> int:
                     continue
                 NUMBER_DEFS[num_key] = num_def
             continue
+        if key == "air_conditioners" and isinstance(climate_def, dict):
+            for ac_key, ac_def in climate_def.items():
+                if ac_key.startswith("_") or not isinstance(ac_def, dict):
+                    continue
+                AC_CLIMATE_DEFS[ac_key] = ac_def
+            continue
         if isinstance(climate_def, dict):
             CLIMATE_DEFS[key] = climate_def
     if climate:
@@ -608,6 +619,20 @@ def get_truma_heater_defs() -> tuple[tuple[str, dict[str, Any]], ...]:
         and isinstance(CLIMATE_DEFS[key], dict)
     )
     return tuple(profiles)
+
+
+def get_air_conditioner_defs() -> tuple[tuple[str, dict[str, Any]], ...]:
+    """Return single-zone air-conditioner climate profiles in stable order.
+
+    Each entry is ``(key, def)`` from the ``"climate"."air_conditioners"`` JSON
+    subsection.  climate.py builds one observation-gated thermostat entity per
+    def, so a vehicle only materialises the A/C climate for the bus it reports.
+    """
+    return tuple(
+        (key, AC_CLIMATE_DEFS[key])
+        for key in sorted(AC_CLIMATE_DEFS)
+        if isinstance(AC_CLIMATE_DEFS[key], dict)
+    )
 
 
 # Human-readable mappings for raw SCU string values

--- a/custom_components/hymer_connect/sensor_maps/base.json
+++ b/custom_components/hymer_connect/sensor_maps/base.json
@@ -1120,6 +1120,51 @@
       "cooling_step_sensor": "fridge_cooling_step",
       "mode_sensor": "fridge_mode"
     },
+    "air_conditioners": {
+      "_doc": "Single-zone air-conditioner climate entities (v2.78.0+). Each def aggregates the standard 4-slot AC layout into one HA climate (thermostat) card: target-temperature (slot 1, float), current/room temperature (slot 2, read), HVAC mode (slot 3, string AIRCON_MODE_OPTIONS OFF/FAN/COOL/HEAT/DEHUMIDIFY/VENTILATION/AUTO) and fan mode (slot 4, string FAN_MODE_OPTIONS OFF/LOW/MID/HIGH/NIGHT/AUTO). Observation-gated on the mode readback sensor so it only materialises on a vehicle that reports the bus. The slot-level select/number controls for the same slots stay available for granular control. Dual-zone Airxcel (bus 95, separate heat/cool targets) is handled by its slot-level controls for now. WRITE PATHS UNVERIFIED - test controls.",
+      "ac_teleco": {
+        "require_observed": true,
+        "name": "Teleco DualClima",
+        "control_bus": 36,
+        "target_sid": 1,
+        "mode_sid": 3,
+        "fan_sid": 4,
+        "min_temp": 16,
+        "max_temp": 32,
+        "target_sensor": "teleco_target_temp",
+        "current_sensor": "teleco_room_temperature",
+        "mode_sensor": "teleco_aircon_mode",
+        "fan_sensor": "teleco_fan_mode"
+      },
+      "ac_saphir_compact": {
+        "require_observed": true,
+        "name": "Saphir Compact",
+        "control_bus": 79,
+        "target_sid": 1,
+        "mode_sid": 3,
+        "fan_sid": 4,
+        "min_temp": 16,
+        "max_temp": 32,
+        "target_sensor": "saphir_compact_target_temp",
+        "current_sensor": "saphir_compact_room_temperature",
+        "mode_sensor": "saphir_compact_aircon_mode",
+        "fan_sensor": "saphir_compact_fan_mode"
+      },
+      "ac_saphir_rc": {
+        "require_observed": true,
+        "name": "Saphir Comfort RC",
+        "control_bus": 89,
+        "target_sid": 1,
+        "mode_sid": 3,
+        "fan_sid": 4,
+        "min_temp": 16,
+        "max_temp": 32,
+        "target_sensor": "saphir_rc_target_temp",
+        "current_sensor": "saphir_rc_room_temperature",
+        "mode_sensor": "saphir_rc_aircon_mode",
+        "fan_sensor": "saphir_rc_fan_mode"
+      }
+    },
     "selects": {
       "fridge_dometic_cooling_step": {
         "_doc": "Dometic compressor fridge (bus 60 = DometicCompressorFridge) Off/1-5 cooling-step control. Ground truth from the decompiled EHG app (componentId 60): PowerOn = slot 8 (bool rw), Temperature = slot 2 (int rw, range 1-5, NO 0/Off). Mirrors the Thetford drivers (bus 34/32/114): power sid 8 (bool) then cooling-step sid 2 (uint). Off routes to PowerOn=false. Both the cooling-level write (slot 2) AND the on/off write (slot 8, Off branch) CONFIRMED on-vehicle by HYMER Dometic owner 'Jos' (2026-08-23). require_observed: created only when bus 60 is reported.",


### PR DESCRIPTION
## Aggregated A/C thermostat (`climate`) entities for single-zone air conditioners

Builds on the v2.77.0 component adoption (MaxxFan + A/B/C slot-level controls) by adding a proper Home Assistant **climate card** for the single-zone air conditioners.

### What this adds
- **`HymerACClimate`** — a JSON-driven single-zone A/C climate entity exposing:
  - HVAC mode: Off / Cool / Heat / Fan / Dry / Auto (from slot 3, `AIRCON_MODE_OPTIONS`)
  - Target temperature (slot 1, float) + current/room temperature (slot 2, read)
  - Fan mode: Off / Low / Mid / High / Night / Auto (slot 4, `FAN_MODE_OPTIONS`)
- Covers **Teleco Telair DualClima (bus 36)**, **Truma Saphir Compact (bus 79)** and **Saphir Comfort RC (bus 89)** with one reusable class.
- New `climate.air_conditioners` JSON section + `get_air_conditioner_defs()` loader (mirrors the existing `truma_heater` pattern).

### Safety
- Every entity is **observation-gated** (`require_observed`) — created **only** when the vehicle reports the bus, so existing vehicles are unaffected and no entity IDs change.
- **Write paths are UNVERIFIED** (test controls): enum wire values are taken from the decompiled EHG app and cross-checked with [@dan-simms1's](https://github.com/dan-simms1/hymer-connect-ha) resolved constants, but not yet confirmed on a real A/C-equipped vehicle.
- The granular per-slot select/number controls added in v2.77.0 remain available.

### Not in this PR (follow-ups)
- Dual-zone **Airxcel AC Gateway** (bus 95) aggregated climate — needs the separate heat/cool target-range thermostat model.
- **Timberline** heaters (buses 124/125) aggregated climate card.

### Verification
- `base.json` valid; all gating/collision/select harnesses pass; `climate.py` + `pia_decoder.py` AST-clean.
- Coordinator/entity lifecycle is not unit-testable on the dev host (needs a running HA), so the write path is shipped UNVERIFIED and gated.

Bumps to **v2.78.0**.
