### PR TITLE
feat(climate): dual-zone Airxcel + Timberline thermostat cards (v2.80.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.80.0] - 2026-08-25
+
+### Added
+
+- **Dual-zone Airxcel A/C thermostat (`climate`) entities.** The Airxcel AC Gateway (bus 95) now exposes a **front** and a **rear** Home Assistant climate card with **separate heat/cool target temperatures**: HVAC mode (Off/Cool/Heat/Heat-Cool/Fan), a target-temperature range in the Heat-Cool mode (low = heat, high = cool), current/ambient temperature, and a combined fan mode (Auto + Low/Med/High). Enum wire values match the decompiled EHG app (`AIRXCEL_AC_MODES` / `AIRXCEL_FAN_SPEEDS`).
+- **Timberline air-heater thermostat (`climate`) entity.** The Timberline zone heater (bus 125) now exposes a climate card driven by its int-enum mode slot (Off/Heat/Fan) plus target + ambient temperature.
+
+Both build on the slot-level controls shipped in v2.77.0 and complete the aggregated climate cards begun in v2.78.0 (Teleco/Saphir). Every entity is **observation-gated** (created only when the vehicle reports the bus), so existing vehicles are unaffected and no entity IDs change. **Write paths are UNVERIFIED** test controls until confirmed on-vehicle; the granular per-slot select/number controls remain available. As always after a HACS update, **restart** Home Assistant.
+
 ## [2.79.0] - 2026-08-25
 
 ### Fixed

--- a/custom_components/hymer_connect/climate.py
+++ b/custom_components/hymer_connect/climate.py
@@ -44,12 +44,26 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up HYMER Connect climate from a config entry."""
-    from .pia_decoder import get_air_conditioner_defs, get_truma_heater_defs
+    from .pia_decoder import (
+        get_air_conditioner_defs,
+        get_airxcel_zone_defs,
+        get_modern_heater_defs,
+        get_truma_heater_defs,
+    )
 
     coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     # Single-zone air-conditioners (Teleco / Saphir …) — each observation-gated.
     _setup_air_conditioners(coordinator, entry, async_add_entities, get_air_conditioner_defs())
+    # Airxcel dual-zone A/C (front/rear) + modern enum heaters (Timberline).
+    _setup_gated_climate(
+        coordinator, entry, async_add_entities,
+        get_airxcel_zone_defs(), HymerAirxcelClimate, "Airxcel zone",
+    )
+    _setup_gated_climate(
+        coordinator, entry, async_add_entities,
+        get_modern_heater_defs(), HymerModernHeaterClimate, "Modern heater",
+    )
 
     heater_defs = get_truma_heater_defs()
     if not heater_defs:
@@ -486,3 +500,326 @@ class HymerACClimate(CoordinatorEntity[HymerConnectCoordinator], ClimateEntity):
                 except (ValueError, TypeError):
                     pass
         super()._handle_coordinator_update()
+
+
+try:  # ATTR_TARGET_TEMP_LOW/HIGH moved across HA cores
+    from homeassistant.components.climate.const import (
+        ATTR_TARGET_TEMP_HIGH,
+        ATTR_TARGET_TEMP_LOW,
+    )
+except ImportError:  # pragma: no cover
+    from homeassistant.const import ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW
+
+_HEAT_COOL_MODE = getattr(HVACMode, "HEAT_COOL", HVACMode.AUTO)
+_TARGET_RANGE_FEATURE = getattr(ClimateEntityFeature, "TARGET_TEMPERATURE_RANGE", 0)
+
+_AIRXCEL_MODE_TO_HVAC: dict[str, HVACMode] = {
+    "OFF": HVACMode.OFF,
+    "COOL": HVACMode.COOL,
+    "HEAT": HVACMode.HEAT,
+    "AUTO_HEAT_COOL": _HEAT_COOL_MODE,
+    "FAN_ONLY": HVACMode.FAN_ONLY,
+    "AUX_HEAT": HVACMode.HEAT,
+}
+_AIRXCEL_HVAC_TO_MODE: dict[HVACMode, str] = {
+    HVACMode.OFF: "OFF",
+    HVACMode.COOL: "COOL",
+    HVACMode.HEAT: "HEAT",
+    _HEAT_COOL_MODE: "AUTO_HEAT_COOL",
+    HVACMode.FAN_ONLY: "FAN_ONLY",
+}
+_AIRXCEL_FAN_MODES = ["AUTO", "LOW", "MED", "HIGH"]
+
+# Modern enum-heater option -> HA HVAC (Timberline air heater).
+_MODERN_MODE_TO_HVAC: dict[str, HVACMode] = {
+    "OFF": HVACMode.OFF,
+    "HEAT": HVACMode.HEAT,
+    "HEATING": HVACMode.HEAT,
+    "FAN_ONLY": HVACMode.FAN_ONLY,
+    "VENTILATING": HVACMode.FAN_ONLY,
+}
+
+
+def _setup_gated_climate(
+    coordinator: HymerConnectCoordinator,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    defs: tuple[tuple[str, dict[str, Any]], ...],
+    cls: type,
+    label: str,
+) -> None:
+    """Create one observation-gated climate entity per def, on the mode sensor."""
+    if not defs:
+        return
+    created: set[str] = set()
+
+    @callback
+    def _discover() -> None:
+        if not coordinator.data:
+            return
+        sensors = coordinator.data.get("signalr_sensors")
+        if not isinstance(sensors, dict):
+            return
+        for key, cdef in defs:
+            if key in created:
+                continue
+            gate = cdef.get("mode_sensor") or cdef.get("current_sensor")
+            if cdef.get("require_observed") and gate and gate not in sensors:
+                continue
+            created.add(key)
+            async_add_entities([cls(coordinator, entry, key, cdef)])
+            _LOGGER.info("%s climate materialised: %s (bus %s)",
+                         label, key, cdef.get("control_bus"))
+
+    _discover()
+    entry.async_on_unload(coordinator.async_add_listener(_discover))
+
+
+class HymerAirxcelClimate(CoordinatorEntity[HymerConnectCoordinator], ClimateEntity):
+    """Airxcel dual-zone A/C climate with separate heat/cool targets."""
+
+    _attr_has_entity_name = True
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1.0
+    _attr_icon = "mdi:air-conditioner"
+    _attr_fan_modes = _AIRXCEL_FAN_MODES
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.FAN_MODE
+        | _TARGET_RANGE_FEATURE
+    )
+
+    def __init__(self, coordinator, entry, key, cdef) -> None:
+        super().__init__(coordinator)
+        self._bus = int(cdef["control_bus"])
+        self._mode_sid = int(cdef["mode_sid"])
+        self._fan_mode_sid = int(cdef["fan_mode_sid"])
+        self._fan_speed_sid = int(cdef["fan_speed_sid"])
+        self._heat_sid = int(cdef["heat_sid"])
+        self._cool_sid = int(cdef["cool_sid"])
+        self._mode_sensor = cdef.get("mode_sensor", "")
+        self._fan_mode_sensor = cdef.get("fan_mode_sensor", "")
+        self._fan_speed_sensor = cdef.get("fan_speed_sensor", "")
+        self._heat_sensor = cdef.get("heat_sensor", "")
+        self._cool_sensor = cdef.get("cool_sensor", "")
+        self._current_sensor = cdef.get("current_sensor", "")
+        self._attr_min_temp = float(cdef.get("min_temp", 10))
+        self._attr_max_temp = float(cdef.get("max_temp", 35))
+        self._attr_name = cdef.get("name", "Airxcel A/C")
+        self._attr_unique_id = f"{entry.entry_id}_airxcel_{key}_b{self._bus}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": "HYMER",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        self._attr_hvac_modes = [
+            HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT,
+            _HEAT_COOL_MODE, HVACMode.FAN_ONLY,
+        ]
+
+    def _sensor(self, name: str) -> Any:
+        if not name or self.coordinator.data is None:
+            return None
+        return _resolve_path(self.coordinator.data, f"signalr_sensors.{name}")
+
+    def _temp(self, name: str) -> float | None:
+        val = self._sensor(name)
+        try:
+            f = float(val) if val is not None else None
+        except (ValueError, TypeError):
+            return None
+        return f if f is not None and f > HEATER_OFF_SETPOINT else None
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        raw = self._sensor(self._mode_sensor)
+        return _AIRXCEL_MODE_TO_HVAC.get(raw.upper()) if isinstance(raw, str) else None
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        mode = self.hvac_mode
+        if mode == HVACMode.COOL:
+            return HVACAction.COOLING
+        if mode == HVACMode.HEAT:
+            return HVACAction.HEATING
+        if mode == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+        if mode == HVACMode.OFF:
+            return HVACAction.OFF
+        return HVACAction.IDLE
+
+    @property
+    def current_temperature(self) -> float | None:
+        return self._temp(self._current_sensor)
+
+    @property
+    def target_temperature(self) -> float | None:
+        if self.hvac_mode == _HEAT_COOL_MODE:
+            return None
+        if self.hvac_mode in (HVACMode.COOL, HVACMode.FAN_ONLY):
+            return self._temp(self._cool_sensor)
+        return self._temp(self._heat_sensor)
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        return self._temp(self._heat_sensor) if self.hvac_mode == _HEAT_COOL_MODE else None
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        return self._temp(self._cool_sensor) if self.hvac_mode == _HEAT_COOL_MODE else None
+
+    @property
+    def fan_mode(self) -> str | None:
+        fm = self._sensor(self._fan_mode_sensor)
+        if isinstance(fm, str) and fm.upper() == "AUTO":
+            return "AUTO"
+        fs = self._sensor(self._fan_speed_sensor)
+        return fs if isinstance(fs, str) and fs in _AIRXCEL_FAN_MODES else None
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        wire = _AIRXCEL_HVAC_TO_MODE.get(hvac_mode)
+        if wire is None:
+            return
+        await self.coordinator.async_send_multi_sensor_command([
+            {"bus_id": self._bus, "sensor_id": self._mode_sid, "str_value": wire},
+        ])
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        low = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        cmds: list[dict[str, Any]] = []
+        if low is not None and high is not None:
+            cmds.append({"bus_id": self._bus, "sensor_id": self._heat_sid, "float_value": float(low)})
+            cmds.append({"bus_id": self._bus, "sensor_id": self._cool_sid, "float_value": float(high)})
+        else:
+            temp = kwargs.get(ATTR_TEMPERATURE)
+            if temp is None:
+                return
+            sid = self._cool_sid if self.hvac_mode in (HVACMode.COOL, HVACMode.FAN_ONLY) else self._heat_sid
+            cmds.append({"bus_id": self._bus, "sensor_id": sid, "float_value": float(temp)})
+        await self.coordinator.async_send_multi_sensor_command(cmds)
+        self.async_write_ha_state()
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        if fan_mode not in _AIRXCEL_FAN_MODES:
+            return
+        if fan_mode == "AUTO":
+            cmds = [{"bus_id": self._bus, "sensor_id": self._fan_mode_sid, "str_value": "AUTO"}]
+        else:
+            cmds = [
+                {"bus_id": self._bus, "sensor_id": self._fan_mode_sid, "str_value": "ON"},
+                {"bus_id": self._bus, "sensor_id": self._fan_speed_sid, "str_value": fan_mode},
+            ]
+        await self.coordinator.async_send_multi_sensor_command(cmds)
+        self.async_write_ha_state()
+
+
+class HymerModernHeaterClimate(CoordinatorEntity[HymerConnectCoordinator], ClimateEntity):
+    """Modern enum-based heater climate (int mode slot + float target)."""
+
+    _attr_has_entity_name = True
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1.0
+    _attr_icon = "mdi:radiator"
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+
+    def __init__(self, coordinator, entry, key, cdef) -> None:
+        super().__init__(coordinator)
+        self._bus = int(cdef["control_bus"])
+        self._mode_sid = int(cdef["mode_sid"])
+        self._target_sid = int(cdef["target_sid"])
+        self._mode_sensor = cdef.get("mode_sensor", "")
+        self._target_sensor = cdef.get("target_sensor", "")
+        self._current_sensor = cdef.get("current_sensor", "")
+        self._options: list[str] = [str(o).upper() for o in cdef.get("mode_options", [])]
+        self._attr_min_temp = float(cdef.get("min_temp", 5))
+        self._attr_max_temp = float(cdef.get("max_temp", 35))
+        self._attr_name = cdef.get("name", "Heater")
+        self._attr_unique_id = f"{entry.entry_id}_modern_heater_{key}_b{self._bus}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": "HYMER",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        modes: list[HVACMode] = []
+        for opt in self._options:
+            hv = _MODERN_MODE_TO_HVAC.get(opt)
+            if hv is not None and hv not in modes:
+                modes.append(hv)
+        if HVACMode.OFF not in modes:
+            modes.insert(0, HVACMode.OFF)
+        self._attr_hvac_modes = modes or [HVACMode.OFF, HVACMode.HEAT]
+
+    def _sensor(self, name: str) -> Any:
+        if not name or self.coordinator.data is None:
+            return None
+        return _resolve_path(self.coordinator.data, f"signalr_sensors.{name}")
+
+    def _mode_index(self) -> int | None:
+        raw = self._sensor(self._mode_sensor)
+        try:
+            return int(raw) if raw is not None else None
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        idx = self._mode_index()
+        if idx is None or idx < 0 or idx >= len(self._options):
+            return None
+        return _MODERN_MODE_TO_HVAC.get(self._options[idx])
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        mode = self.hvac_mode
+        if mode == HVACMode.HEAT:
+            return HVACAction.HEATING
+        if mode == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+        if mode == HVACMode.OFF:
+            return HVACAction.OFF
+        return HVACAction.IDLE
+
+    @property
+    def current_temperature(self) -> float | None:
+        val = self._sensor(self._current_sensor)
+        try:
+            return float(val) if val is not None else None
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        val = self._sensor(self._target_sensor)
+        try:
+            f = float(val) if val is not None else None
+        except (ValueError, TypeError):
+            return None
+        return f if f is not None and f > HEATER_OFF_SETPOINT else None
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        # Map the requested HVAC mode back to the first matching enum index.
+        target_opt = None
+        for opt in self._options:
+            if _MODERN_MODE_TO_HVAC.get(opt) == hvac_mode:
+                target_opt = opt
+                break
+        if target_opt is None:
+            return
+        idx = self._options.index(target_opt)
+        await self.coordinator.async_send_multi_sensor_command([
+            {"bus_id": self._bus, "sensor_id": self._mode_sid, "uint_value": idx},
+        ])
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is None:
+            return
+        await self.coordinator.async_send_multi_sensor_command([
+            {"bus_id": self._bus, "sensor_id": self._target_sid, "float_value": float(temp)},
+        ])
+        self.async_write_ha_state()

--- a/custom_components/hymer_connect/manifest.json
+++ b/custom_components/hymer_connect/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/BetaHydri/hymer-connect-ha-ble/issues",
   "loggers": ["hymer_connect"],
   "requirements": [],
-  "version": "2.79.0"
+  "version": "2.80.0"
 }

--- a/custom_components/hymer_connect/pia_decoder.py
+++ b/custom_components/hymer_connect/pia_decoder.py
@@ -94,6 +94,14 @@ CLIMATE_DEFS: dict[str, dict[str, Any]] = {}
 # :class:`climate.HymerACClimate` thermostat entity (target/current/mode/fan).
 AC_CLIMATE_DEFS: dict[str, dict[str, Any]] = {}
 
+# Airxcel dual-zone climate definitions (v2.80.0+) from
+# ``"climate"."airxcel_zones"`` (front/rear); drive :class:`climate.HymerAirxcelClimate`.
+AIRXCEL_ZONE_DEFS: dict[str, dict[str, Any]] = {}
+
+# Modern enum-heater climate definitions (v2.80.0+) from
+# ``"climate"."modern_heaters"``; drive :class:`climate.HymerModernHeaterClimate`.
+MODERN_HEATER_DEFS: dict[str, dict[str, Any]] = {}
+
 # Generic stepped-switch select definitions (v2.63.0+) loaded from the
 # ``"climate"."selects"`` JSON subsection.  Drives appliances exposing a
 # small set of integer steps (fridge cooling 1-5, freezer 1-3, fan
@@ -512,6 +520,18 @@ def _load_json_overlay(filename: str) -> int:
                     continue
                 AC_CLIMATE_DEFS[ac_key] = ac_def
             continue
+        if key == "airxcel_zones" and isinstance(climate_def, dict):
+            for z_key, z_def in climate_def.items():
+                if z_key.startswith("_") or not isinstance(z_def, dict):
+                    continue
+                AIRXCEL_ZONE_DEFS[z_key] = z_def
+            continue
+        if key == "modern_heaters" and isinstance(climate_def, dict):
+            for h_key, h_def in climate_def.items():
+                if h_key.startswith("_") or not isinstance(h_def, dict):
+                    continue
+                MODERN_HEATER_DEFS[h_key] = h_def
+            continue
         if isinstance(climate_def, dict):
             CLIMATE_DEFS[key] = climate_def
     if climate:
@@ -632,6 +652,24 @@ def get_air_conditioner_defs() -> tuple[tuple[str, dict[str, Any]], ...]:
         (key, AC_CLIMATE_DEFS[key])
         for key in sorted(AC_CLIMATE_DEFS)
         if isinstance(AC_CLIMATE_DEFS[key], dict)
+    )
+
+
+def get_airxcel_zone_defs() -> tuple[tuple[str, dict[str, Any]], ...]:
+    """Return Airxcel dual-zone climate profiles (front/rear) in stable order."""
+    return tuple(
+        (key, AIRXCEL_ZONE_DEFS[key])
+        for key in sorted(AIRXCEL_ZONE_DEFS)
+        if isinstance(AIRXCEL_ZONE_DEFS[key], dict)
+    )
+
+
+def get_modern_heater_defs() -> tuple[tuple[str, dict[str, Any]], ...]:
+    """Return modern enum-heater climate profiles (e.g. Timberline) in order."""
+    return tuple(
+        (key, MODERN_HEATER_DEFS[key])
+        for key in sorted(MODERN_HEATER_DEFS)
+        if isinstance(MODERN_HEATER_DEFS[key], dict)
     )
 
 

--- a/custom_components/hymer_connect/sensor_maps/base.json
+++ b/custom_components/hymer_connect/sensor_maps/base.json
@@ -1165,6 +1165,61 @@
         "fan_sensor": "saphir_rc_fan_mode"
       }
     },
+    "airxcel_zones": {
+      "_doc": "Airxcel AC Gateway dual-zone climate entities (v2.80.0+). Each zone (front/rear) aggregates the Airxcel slot model into one HA climate card with separate heat/cool target temperatures: HVAC mode (slot 1/17 string AIRXCEL_AC_MODES OFF/COOL/HEAT/AUTO_HEAT_COOL/FAN_ONLY/AUX_HEAT -> Off/Cool/Heat/HeatCool/Fan), heat target (slot 4/20 float) + cool target (slot 5/21 float), ambient (slot 14/30 read), and a combined fan mode (AUTO from slot 2/18 + LOW/MED/HIGH from slot 3/19). In AUTO_HEAT_COOL the card exposes a target range (low=heat, high=cool). Observation-gated on the mode readback. WRITE PATHS UNVERIFIED - test controls. The granular per-slot selects/numbers stay available.",
+      "front": {
+        "require_observed": true,
+        "name": "Airxcel front A/C",
+        "control_bus": 95,
+        "mode_sid": 1,
+        "fan_mode_sid": 2,
+        "fan_speed_sid": 3,
+        "heat_sid": 4,
+        "cool_sid": 5,
+        "min_temp": 10,
+        "max_temp": 35,
+        "mode_sensor": "airxcel_aircon_mode_front",
+        "fan_mode_sensor": "airxcel_aircon_fan_mode_front",
+        "fan_speed_sensor": "airxcel_aircon_fan_speed_front",
+        "heat_sensor": "airxcel_heat_temp_front",
+        "cool_sensor": "airxcel_cool_temp_front",
+        "current_sensor": "airxcel_ambient_temperature_front"
+      },
+      "rear": {
+        "require_observed": true,
+        "name": "Airxcel rear A/C",
+        "control_bus": 95,
+        "mode_sid": 17,
+        "fan_mode_sid": 18,
+        "fan_speed_sid": 19,
+        "heat_sid": 20,
+        "cool_sid": 21,
+        "min_temp": 10,
+        "max_temp": 35,
+        "mode_sensor": "airxcel_aircon_mode_rear",
+        "fan_mode_sensor": "airxcel_aircon_fan_mode_rear",
+        "fan_speed_sensor": "airxcel_aircon_fan_speed_rear",
+        "heat_sensor": "airxcel_heat_temp_rear",
+        "cool_sensor": "airxcel_cool_temp_rear",
+        "current_sensor": "airxcel_ambient_temperature_rear"
+      }
+    },
+    "modern_heaters": {
+      "_doc": "Modern enum-based heater climate entities (v2.80.0+). Aggregates an int-enum air-heater into one HA climate card: HVAC mode from the int mode slot (mapped via mode_values), target temperature (float) and current/ambient temperature (read). Written as uint for the mode, float for the target. Observation-gated on the mode readback. WRITE PATHS UNVERIFIED - test controls. The granular per-slot select/number controls stay available.",
+      "timberline_zone": {
+        "require_observed": true,
+        "name": "Timberline air heater",
+        "control_bus": 125,
+        "mode_sid": 3,
+        "target_sid": 4,
+        "min_temp": 5,
+        "max_temp": 35,
+        "mode_options": ["OFF", "HEAT", "FAN_ONLY"],
+        "mode_sensor": "timberline_air_mode",
+        "target_sensor": "timberline_air_target_temp",
+        "current_sensor": "timberline_zone_ambient_temperature"
+      }
+    },
     "selects": {
       "fridge_dometic_cooling_step": {
         "_doc": "Dometic compressor fridge (bus 60 = DometicCompressorFridge) Off/1-5 cooling-step control. Ground truth from the decompiled EHG app (componentId 60): PowerOn = slot 8 (bool rw), Temperature = slot 2 (int rw, range 1-5, NO 0/Off). Mirrors the Thetford drivers (bus 34/32/114): power sid 8 (bool) then cooling-step sid 2 (uint). Off routes to PowerOn=false. Both the cooling-level write (slot 2) AND the on/off write (slot 8, Off branch) CONFIRMED on-vehicle by HYMER Dometic owner 'Jos' (2026-08-23). require_observed: created only when bus 60 is reported.",


### PR DESCRIPTION
## Dual-zone Airxcel + Timberline aggregated `climate` thermostat cards

Completes the aggregated climate work started in v2.78.0 (Teleco/Saphir single-zone A/C). Builds on the v2.77.0 slot-level controls.

### What this adds
- **`HymerAirxcelClimate`** — dual-zone A/C climate for the Airxcel AC Gateway (bus 95), one entity per zone (**front** + **rear**):
  - HVAC mode Off / Cool / Heat / Heat-Cool / Fan (slot 1/17, `AIRXCEL_AC_MODES`)
  - **Separate heat/cool targets** (slots 4/5 front, 20/21 rear) — exposed as a target-temperature range in Heat-Cool mode, single target otherwise
  - Current/ambient temperature (slot 14/30), combined fan mode (Auto + Low/Med/High)
- **`HymerModernHeaterClimate`** — int-enum air-heater climate for the Timberline zone (bus 125): mode (Off/Heat/Fan, slot 3), target (slot 4) + ambient (slot 11).
- New `climate.airxcel_zones` + `climate.modern_heaters` JSON sections and `get_airxcel_zone_defs()` / `get_modern_heater_defs()` loaders, plus a generic `_setup_gated_climate()` helper.

### Safety
- Every entity is **observation-gated** — created only when the vehicle reports the bus. Existing vehicles are unaffected; no entity IDs change.
- **Write paths are UNVERIFIED** test controls (enum wire values from the decompiled EHG app, cross-checked with @dan-simms1's constants).
- The granular per-slot select/number controls from v2.77.0 remain available.

### Verification
- `base.json` valid; all gating/collision/select harnesses pass; `climate.py` + `pia_decoder.py` AST-clean.
- Entity lifecycle is not unit-testable on the dev host (needs a running HA); shipped UNVERIFIED and gated.

Bumps to **v2.80.0**.
